### PR TITLE
Bugfix schedule interval

### DIFF
--- a/airflow_prometheus_exporter/__init__.py
+++ b/airflow_prometheus_exporter/__init__.py
@@ -4,4 +4,4 @@
 
 __author__ = """Robinhood Markets, Inc."""
 __email__ = "open-source@robinhood.com"
-__version__ = "__version__ = '1.1.0j'"
+__version__ = "__version__ = '1.1.1j'"

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -450,7 +450,7 @@ class MetricsCollector(object):
             labels=["task_id", "dag_id", "execution_date"],
         )
         for task in get_landing_times():
-            if task.schedule_interval:
+            if task.schedule_interval is not None:
                 task_duration_value = (
                     task.end_date - date_range(task.execution_date, num=2, delta=task.schedule_interval)[1]
                 ).total_seconds()

--- a/airflow_prometheus_exporter/prometheus_exporter.py
+++ b/airflow_prometheus_exporter/prometheus_exporter.py
@@ -450,9 +450,13 @@ class MetricsCollector(object):
             labels=["task_id", "dag_id", "execution_date"],
         )
         for task in get_landing_times():
-            task_duration_value = (
-                task.end_date - date_range(task.execution_date, num=2, delta=task.schedule_interval)[1]
-            ).total_seconds()
+            if task.schedule_interval:
+                task_duration_value = (
+                    task.end_date - date_range(task.execution_date, num=2, delta=task.schedule_interval)[1]
+                ).total_seconds()
+            else:
+                task_duration_value = (task.end_date - task.execution_date).total_seconds()
+
             landing_time.add_metric(
                 [task.task_id, task.dag_id, task.execution_date.strftime("%Y-%m-%d-%H-%M")],
                 task_duration_value,

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,5 +1,5 @@
 [bumpversion]
-current_version = 1.1.0j
+current_version = 1.1.1j
 commit = True
 tag = True
 

--- a/setup.py
+++ b/setup.py
@@ -43,7 +43,7 @@ setup(
     packages=find_packages(include=['airflow_prometheus_exporter']),
     include_package_data=True,
     url='https://github.com/robinhood/airflow_prometheus_exporter',
-    version='1.1.0j',
+    version='1.1.1j',
     entry_points={
         'airflow.plugins': [
             'AirflowPrometheus = airflow_prometheus_exporter.prometheus_exporter:AirflowPrometheusPlugin'


### PR DESCRIPTION
Airflow fails when `schedule_interval` is `None`

I failed to see that problem sooner, It just blowed up in production

Is not critical, can wait